### PR TITLE
add 30 day urgency metric

### DIFF
--- a/CVE-DIBS-protocol.md
+++ b/CVE-DIBS-protocol.md
@@ -10,29 +10,29 @@ See also [Introducing CVE-DIBS](https://docs.google.com/document/d/1VTIhNzfgk66Z
 
 ## Concise CVE-DIBS Protocol
 
-More concise vesion of the protocol. See below for more detail.
+Concise vesion of the protocol. See below for more detail.
 
-0 All of the following criteria must be met for opening a Dibs-Request:
+0.0 All of the following criteria must be met for opening a Dibs-Request:
 
-0.1 Vulnerability is [Publicly Disclosed](https://www.cve.org/ResourcesSupport/Glossary#glossaryPubliclyDisclosed)
+0.1 Vulnerability is [Publicly Disclosed](https://www.cve.org/ResourcesSupport/Glossary#glossaryPubliclyDisclosed).
 
-0.2 Vulnerability is "hot" (urgent, see 5.3.1 below)
+0.2 Vulnerability is "hot" (urgent, see 5.3.1 below, Publicly Disclosed for less than 30 days).
 
 0.3 Dibs requester is a CNA with reasonable scope and intention to quickly assign and publish a CVE Record
 
 0.4 Supplier of the affected Product is *not* a CNA.
 
-1 CNA1 makes a Dibs-Request by opening an issue.
+1.0 CNA1 makes a Dibs-Request by opening an issue.
 
-2 Within 8 hours, if nobody responds with a collision (competing claim), CNA1 is clear to proceed.
+2.0 Within 8 hours, if nobody responds with a collision (competing claim), CNA1 is clear to proceed.
 
 2.1 Open question: Must the full length of the timer must expire, giving time for other participating CNAs to respond? Or can the timer may end early with some sort of sufficient consensus among participants. How do we define "sufficient consensus?" At least one CNA-LR must NACK? Some proportion of participants NACK?
 
-3 If someone (CNA2) does respond with a collision before the timer expires, work it out quickly, priority goes to earliest claim of substantial involvement (ongoing CVD, research, analysis work, scope, etc.).
+3.0 If someone (CNA2) does respond with a collision before the timer expires, work it out quickly, priority goes to earliest claim of substantial involvement (for example: ongoing CVD, research, analysis work, appropriate scope).
 
-4 Selected CNA assigns and publishes expeditiously (SHOULD within 2 hours, MUST within 24 hours).
+4.0 Selected CNA assigns and publishes expeditiously (SHOULD within 2 hours, MUST within 24 hours).
 
-5 If no agreement, go to Root/CNA-LR.
+5.0 If no agreement, go to Root/CNA-LR.
 
 ## Detailed CVE-DIBS Protocol
 
@@ -78,17 +78,19 @@ The detailed version. This is largely copied mostly from the Google notes docume
 
 5.2.1 Dibs-Request messages are ordered by time, when an issue was created or a comment added, according to GitHub.
 
-5.3 We probably want to distinguish between two classes of Publicly Disclosed vulnerabilities, hot or not.
+5.3 DIBS distinguishes between two classes of Publicly Disclosed Vulnerabilities, Urgent or Not Urgent ("hot or not"). DIBS is only followed for Urgent Vulnerabilities.
 
-5.3.1 Hot. New, recent, fresh, getting public attention (socials, media), possibly EITW, possibly lacking a clear and authoritative fix, FUD, thrashing, not-working fixes... High pressure and high value in assigning a CVE ID quickly. Examples: CrushFTP.
+5.3.1 One (but not the only) factor in determining urgency is the lenght of time the vulnerability has been Publicly Disclosed. Vulnerabilities that have been Publicly Disclosed less than or equal to 30 days SHOULD be considered as Urgent. Vulnerabilities that have been Publicly Disclosed more than 30 days SHOULD be considered as Not Urgent.
 
-5.3.2 Not. Follow existing guidance, which is essentially to request assignment or delegation from a CNA-LR.
+5.3.2 Urgent (Hot). Recent, fresh, getting public attention (socials, media), possibly EITW, possibly lacking a clear and authoritative fix, FUD, thrashing, not-working fixes. High pressure and high value in assigning a CVE ID quickly. Examples: CrushFTP ([CVE-2025-2825](https://www.cve.org/CVERecord?id=CVE-2025-2825), [CVE-2025-31161](https://www.cve.org/CVERecord?id=CVE-2025-31161)).
 
-5.x Open question:
+5.3.3 Not Urgent (Not). Follow existing guidance, which is essentially to request assignment or delegation from a Root or CNA-LR, according to a strict interpretation of [4.2.1.2](https://www.cve.org/resourcessupport/allresources/cnarules#section_4-2_CVE_ID_Assignment).
 
-5.x.1 The full length of the timer must expire, giving time for other participating CNAs to respond.
+5.x Open questions:
 
-5.x.2 The timer may end early with some sort of sufficient consensus among participants. How do we define "sufficient consensus?" At least one CNA-LR must NACK? Some proportion of participants NACK?
+5.x.1 The full duration of the timer must expire, giving time for other participating CNAs to respond.
+
+5.x.2 The timer MAY expire early with some sort of sufficient consensus among participants. How do we define "sufficient consensus?" At least one CNA-LR must NACK? Some proportion of participants NACK?
 
 5.4 If a participant responds in agreement, great, that's nice, optional, but can help R learn that other participants are not making conflicting claims. A Dibs-Agree message is reassuring, informational, and optional. Generally, these are "negative" responses -- the responding participant has no intent to assign.
 


### PR DESCRIPTION
cc @wadesparks @ccondon-vc @cve-team

IMO this should be lower than 30 days, but propsing 30 as a starting point. As worded in this PR, age of public disclosure is not the only factor, but it could be made a strict requirement in the future.

Older than X: MUST not DIBS
Newer than Y: MUST DIBS
In between Y and X: MAY DIBS